### PR TITLE
13: Map Headers Before Collect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.lifeomic</groupId>
     <artifactId>spark-vcf</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spark VCF</name>

--- a/src/main/scala/com/lifeomic/variants/VCFResourceRelation.scala
+++ b/src/main/scala/com/lifeomic/variants/VCFResourceRelation.scala
@@ -61,8 +61,8 @@ class VCFResourceRelation(
     private val quickLoad = vcf.filter(!col(TEXT_VALUE).startsWith("##"))
 
     private val headerMap = quickLoad.filter(col(TEXT_VALUE).startsWith("#"))
-        .collect()
         .map(item => (item.getString(0), item.getString(1).split("\t")))
+        .collect()
         .toMap
 
     private val headerMapBroadcast = sqlContext.sparkContext.broadcast(headerMap)


### PR DESCRIPTION
These changes perform the mapping from raw headers to key->value tuples in the dataframe before collecting. Bump the version to 0.3.2.